### PR TITLE
update credData to use only digest value.

### DIFF
--- a/signer-web-app/src/App.tsx
+++ b/signer-web-app/src/App.tsx
@@ -131,9 +131,9 @@ const App: React.FC = () => {
     setPending(true);
     setIsAttestationIssued(false);
     try {
-      let schemaSaid = 'ENDcMNUZjag27T_GTxiCmB2kYstg_kqipqz39906E_FD';
+      let schemaSaid = 'EB4AsU1rKGOAf7m4MS324XhanXq8G01sR_bUdUV2TULm';
       // Todo: remove digestAlgo 
-      let credData = { digest: dataDigest, digestAlgo: 'SHA-256' };
+      let credData = { digest: dataDigest };
       if (!extensionClient) {
         throw new Error('Extension client not initialized');
       }

--- a/verifier/scripts/keri/cf/verifier-config-docker.json
+++ b/verifier/scripts/keri/cf/verifier-config-docker.json
@@ -13,7 +13,7 @@
     "http://host.docker.internal:7723/oobi/ENPXp1vQzRF6JwIuS-mp2U8Uf1MoADoP_GqQ62VsDZWY",
     "http://host.docker.internal:7723/oobi/EH6ekLjSr8V32WyFbGe1zXjTzFs9PkTYmupJ9H65O14g",
     "http://host.docker.internal:7723/oobi/EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao",
-    "http://host.docker.internal:7723/oobi/ENDcMNUZjag27T_GTxiCmB2kYstg_kqipqz39906E_FD"
+    "http://host.docker.internal:7723/oobi/EB4AsU1rKGOAf7m4MS324XhanXq8G01sR_bUdUV2TULm"
   ],
   "LEIs": []
 }

--- a/verifier/scripts/keri/cf/verifier-config-public.json
+++ b/verifier/scripts/keri/cf/verifier-config-public.json
@@ -13,7 +13,7 @@
     "https://schemas.enauthn.dev/oobi/ENPXp1vQzRF6JwIuS-mp2U8Uf1MoADoP_GqQ62VsDZWY",
     "https://schemas.enauthn.dev/oobi/EH6ekLjSr8V32WyFbGe1zXjTzFs9PkTYmupJ9H65O14g",
     "https://schemas.enauthn.dev/oobi/EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao",
-    "https://attestation-schema.enauthn.dev/oobi/ENDcMNUZjag27T_GTxiCmB2kYstg_kqipqz39906E_FD"
+    "https://attestation-schema.enauthn.dev/oobi/EB4AsU1rKGOAf7m4MS324XhanXq8G01sR_bUdUV2TULm"
   ],
   "LEIs": [
     "984500E5DEFDBQ1O9038",

--- a/verifier/scripts/keri/cf/verifier-config.json
+++ b/verifier/scripts/keri/cf/verifier-config.json
@@ -13,7 +13,7 @@
     "http://127.0.0.1:7723/oobi/ENPXp1vQzRF6JwIuS-mp2U8Uf1MoADoP_GqQ62VsDZWY",
     "http://127.0.0.1:7723/oobi/EH6ekLjSr8V32WyFbGe1zXjTzFs9PkTYmupJ9H65O14g",
     "http://127.0.0.1:7723/oobi/EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao",
-    "http://127.0.0.1:7723/oobi/ENDcMNUZjag27T_GTxiCmB2kYstg_kqipqz39906E_FD"
+    "http://127.0.0.1:7723/oobi/EB4AsU1rKGOAf7m4MS324XhanXq8G01sR_bUdUV2TULm"
   ],
   "LEIs": []
 }

--- a/verifier/src/verifier/app/cli/commands/server/start.py
+++ b/verifier/src/verifier/app/cli/commands/server/start.py
@@ -14,7 +14,7 @@ from keri.app import keeping, configing, habbing, oobiing
 from keri.app.cli.common import existing
 from keri.vdr import viring
 import logging
-from verifier.core import verifying, basing
+from verifier.core import verifying
 from falcon_multipart.middleware import MultipartMiddleware
 
 parser = argparse.ArgumentParser(description='Launch vLEI Verification Service')


### PR DESCRIPTION
Update the `doc-signing-web-app` branch `cleaning` to integrate the new public schema (attestation) and fix the base import error.
